### PR TITLE
Use fancy grid sizing to automatically determine column count

### DIFF
--- a/src/assets/stylesheets/components/team-member.sass
+++ b/src/assets/stylesheets/components/team-member.sass
@@ -8,7 +8,7 @@
 .team-member-wrapper
   display: grid
   grid-gap: 1.5rem
-  grid-template-columns: repeat(1, 1fr)
+  grid-template-columns: repeat(auto-fit, minmax(27rem, 1fr))
   grid-template-rows: auto
   justify-content: space-around
   max-width: 120rem
@@ -16,10 +16,6 @@
 
   +mediawidth(md)
     grid-gap: 3rem
-    grid-template-columns: repeat(3, 1fr)
-
-  +mediawidth(lg)
-    grid-template-columns: repeat(4, 1fr)
 
 .team-member
   align-items: center


### PR DESCRIPTION
`repeat(auto-fit, <size>)` will repeat the `size` however many times
it can before the columns overflow. We can use this because the grid
has a determined width.
Note that there is a slight difference between `auto-fit` and
`auto-fill` but I don't know what it is and it seems to not matter in
this case.

The size for each column is `minmax(27rem, 1fr)`. This means that the
minimum width of each column would be `27rem`, and the maximum would
be `1fr`, meaning all columns will share the same width.

What this means is that the rendering engine will try to fit as many
columns (with a width of `27rem`) as it can. then it will distribute
the width equally between these columns. This is neat.
