### PR TITLE
Fix appearance of active and inactive team filter buttons

### DIFF
--- a/src/javascript/App.js
+++ b/src/javascript/App.js
@@ -106,16 +106,16 @@ const App = () => {
             <p className='settings__item__name'>
               { `Team filter: ` }
             </p>
-            <button className={`${teamInView === 'ECT' ? 'inactive' : ''}`} onClick={(): void => setTeamInView('ECT')}>
+            <button className={`${teamInView === 'ECT' ? '' : 'inactive'}`} onClick={(): void => setTeamInView('ECT')}>
               { `ECT` }
             </button>
-            <button className={`${teamInView === 'NCT' ? 'inactive' : ''}`} onClick={(): void => setTeamInView('NCT')}>
+            <button className={`${teamInView === 'NCT' ? '' : 'inactive'}`} onClick={(): void => setTeamInView('NCT')}>
               { `NCT` }
             </button>
-            <button className={`${teamInView === 'Platform' ? 'inactive' : ''}`} onClick={(): void => setTeamInView('Platform')}>
+            <button className={`${teamInView === 'Platform' ? '' : 'inactive'}`} onClick={(): void => setTeamInView('Platform')}>
               { `Platform` }
             </button>
-            <button className={`${teamInView === 'All' ? 'inactive' : ''}`} onClick={(): void => setTeamInView('All')}>
+            <button className={`${teamInView === 'All' ? '' : 'inactive'}`} onClick={(): void => setTeamInView('All')}>
               { `All` }
             </button>
           </div>


### PR DESCRIPTION
This commit fixes the styling of the team filter setting buttons in which the
active filter would appear 'inactive' and grayed out. This had the confusing
affect of understanding what team was currently in view.