### PR TITLE
Show Timezone flag for each Team Member

### DIFF
--- a/src/assets/stylesheets/components/team-member.sass
+++ b/src/assets/stylesheets/components/team-member.sass
@@ -25,6 +25,7 @@
   display: flex
   margin: 0 auto
   padding: 1rem
+  position: relative
   width: 100%
 
   &__avatar
@@ -71,4 +72,14 @@
       color: $brand-blue-400
       font-family: $font-family-base
       font-size: $micro
+
+  &__country
+    background: $grey-200
+    border-radius: 50%
+    height: 2rem
+    object-fit: cover
+    position: absolute
+    right: 1rem
+    top: 1rem
+    width: 2rem
 

--- a/src/javascript/components/TeamMember.js
+++ b/src/javascript/components/TeamMember.js
@@ -4,6 +4,7 @@ import * as React from 'react'
 
 // Utils
 import moment from 'moment-timezone'
+import { zones } from 'moment-timezone/data/meta/latest.json'
 
 // Context
 import Show24HourTimeContext from '../Show24HourTimeContext'
@@ -38,12 +39,16 @@ const TeamMember = ({ name, timezone, gender, avatarUrl }: Props): React.Node =>
     }
   }
 
+  const getCountryCode = (zone: $PropertyType<TeamMemberType, 'timezone'>): string => {
+    return zones[zone] && zones[zone].countries[0]
+  }
+
   return (
     <div className='team-member'>
       <div className='team-member__avatar'>
         <div className={`team-member__avatar__day-night-indicator ${isOnline(time.hour())}`} />
         <img
-          alt=''
+          alt={name}
           className='team-member__avatar__image'
           src={avatarUrl}
         />
@@ -62,6 +67,11 @@ const TeamMember = ({ name, timezone, gender, avatarUrl }: Props): React.Node =>
         <small className='team-member__information__timezone'>
           { timezone }
         </small>
+        <img
+          alt={getCountryCode(timezone)}
+          className='team-member__country'
+          src={`http://catamphetamine.gitlab.io/country-flag-icons/3x2/${getCountryCode(timezone)}.svg`}
+        />
       </div>
     </div>
   )


### PR DESCRIPTION
This commit introduces a new feature to the TeamMember component that presents a
flag in the top right corner which matches that team members local timezone.

This feature will therefore help to display a more geographical representation
of all of our Team rather than just a written timezone.