### PR TITLE
Add Netlify function for checking TeamMember Slack presence

### DIFF
--- a/functions/slackOnlineStatus.js
+++ b/functions/slackOnlineStatus.js
@@ -1,0 +1,19 @@
+const fetch = require('node-fetch')
+
+const { SLACK_AUTHORIZATION_TOKEN } = process.env
+
+exports.handler = async (event, context) => {
+  const slackUserID = event.queryStringParameters.userID
+  const API_ENDPOINT = `https://slack.com/api/users.getPresence?token=${SLACK_AUTHORIZATION_TOKEN}&user=${slackUserID}`
+
+  return fetch(API_ENDPOINT, { headers: { Accept: 'application/json' } })
+    .then(response => response.json())
+    .then(data => ({
+      headers: {
+        "Access-Control-Allow-Origin": "*"
+      },
+      statusCode: 200,
+      body: data.presence
+    }))
+    .catch(error => ({ statusCode: 422, body: String(error) }))
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "flow-bin": "^0.128.0",
     "moment-timezone": "^0.5.31",
+    "node-fetch": "^2.6.0",
     "node-sass": "^4.14.1",
     "normalize-scss": "^7.0.1",
     "react": "^16.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7374,6 +7374,11 @@ no-case@^3.0.3:
     lower-case "^2.0.1"
     tslib "^1.10.0"
 
+node-fetch@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+
 node-forge@0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.9.0.tgz#d624050edbb44874adca12bb9a52ec63cb782579"


### PR DESCRIPTION
This commit adds support for a Netlify function which can check the `presence`
of a TeamMember using the Slack Web API.

Once this function is deployed, we are able to pro actively show accurate on line
status that doesn't rely on timezone and hours alone.