### PR TITLE
Display online status from Slack API

### DIFF
--- a/src/assets/stylesheets/components/team-member.sass
+++ b/src/assets/stylesheets/components/team-member.sass
@@ -32,11 +32,13 @@
     position: relative
 
     &__day-night-indicator
+      background: $grey-200
       border-radius: 50%
       height: 2rem
       position: absolute
       right: .5rem
       top: .5rem
+      transition: background .25s ease
       width: 2rem
 
       &--offline

--- a/src/javascript/App.js
+++ b/src/javascript/App.js
@@ -81,13 +81,14 @@ const App = () => {
           <Show24HourTimeProvider value={is24Hour}>
             <CurrentTimeProvider value={currentTime}>
               {
-                filteredTeamMembers.map(({ name, timezone, gender, avatarUrl }: TeamMemberType): React.Element<typeof TeamMember> => (
+                filteredTeamMembers.map(({ name, timezone, gender, avatarUrl, onlineStatus }: TeamMemberType): React.Element<typeof TeamMember> => (
                   <TeamMember
                     name={name}
                     timezone={timezone}
                     gender={gender}
                     avatarUrl={avatarUrl}
                     key={name}
+                    onlineStatus={onlineStatus}
                   />
                 ))
               }

--- a/src/javascript/components/TeamMember.js
+++ b/src/javascript/components/TeamMember.js
@@ -15,29 +15,28 @@ type Props = {|
   name: $PropertyType<TeamMemberType, 'name'>,
   timezone: $PropertyType<TeamMemberType, 'timezone'>,
   gender: $PropertyType<TeamMemberType, 'gender'>,
-  avatarUrl: $PropertyType<TeamMemberType, 'avatarUrl'>
+  avatarUrl: $PropertyType<TeamMemberType, 'avatarUrl'>,
+  onlineStatus: $PropertyType<TeamMemberType, 'onlineStatus'>
 |}
 
-const TeamMember = ({ name, timezone, gender, avatarUrl }: Props): React.Node => {
+const TeamMember = ({ name, timezone, gender, avatarUrl, onlineStatus }: Props): React.Node => {
   const show24HourTime = React.useContext(Show24HourTimeContext)
   const currentTime = React.useContext(CurrentTimeContext)
-
-  const isOnline = (hour: number): string => {
-    if (hour < 18 && hour >= 9 ) {
-      return 'team-member__avatar__day-night-indicator--online'
-    } else {
-      return 'team-member__avatar__day-night-indicator--offline'
-    }
-  }
+  const [isOnline, setIsOnline] = React.useState(false)
 
   const getCountryCode = (zone: $PropertyType<TeamMemberType, 'timezone'>): string => {
     return zones[zone] && zones[zone].countries[0]
   }
 
+  onlineStatus.then(response => (
+      response === 'active' ? setIsOnline(true) : setIsOnline(false)
+    )
+  )
+
   return (
     <div className='team-member'>
       <div className='team-member__avatar'>
-        <div className={`team-member__avatar__day-night-indicator ${isOnline(currentTime.tz(timezone).hour())}`} />
+        <div className={`team-member__avatar__day-night-indicator ${isOnline ? 'team-member__avatar__day-night-indicator--online' : 'team-member__avatar__day-night-indicator--offline'}`} />
         <img
           alt={name}
           className='team-member__avatar__image'
@@ -50,13 +49,13 @@ const TeamMember = ({ name, timezone, gender, avatarUrl }: Props): React.Node =>
         </h2>
         <p className='team-member__information__current-time'>
           <React.Suspense fallback={<p>Loading...</p>}>
-          {
-            currentTime.tz(timezone).format(
-              show24HourTime
-                ? 'HH:mm'
-                : 'hh:mm A'
-            )
-          }
+            {
+              currentTime.tz(timezone).format(
+                show24HourTime
+                  ? 'HH:mm'
+                  : 'hh:mm A'
+              )
+            }
           </React.Suspense>
         </p>
         <small className='team-member__information__timezone'>

--- a/src/javascript/data/teamMembers.js
+++ b/src/javascript/data/teamMembers.js
@@ -10,13 +10,24 @@ type Gender =
   | 'male'
   | 'female'
 
-type TeamMember = {
+type TeamMember = {|
   name: string,
   timezone: string,
   gender: Gender,
   avatarUrl: string,
-  team: Team
+  team: Team,
+  onlineStatus: Promise<any>
+|}
+
+const fetchOnlineStatus = (teamMemberId: string): Promise<any> => {
+  const endpoint = `https://existingcustomerteam.netlify.app/.netlify/functions/slackOnlineStatus?userID=${teamMemberId}`
+
+  return fetch(endpoint)
+    .then(response => response.text())
+    .then(data => data)
+    .catch(error => ({ statusCode: 422, body: String(error) }))
 }
+
 
 const TeamMembers: Array<TeamMember> = [
   {
@@ -24,119 +35,136 @@ const TeamMembers: Array<TeamMember> = [
     timezone: 'Europe/London',
     gender: 'male',
     avatarUrl: 'https://ca.slack-edge.com/T0P6BBP1N-UC7HELUHK-496bfc0bd71e-512',
-    team: 'ECT'
+    team: 'ECT',
+    onlineStatus: fetchOnlineStatus('UC7HELUHK')
   },
   {
     name: 'Ryan',
     timezone: 'America/Toronto',
     gender: 'male',
     avatarUrl: 'https://ca.slack-edge.com/T0P6BBP1N-UCL31R6KU-03571b8c9038-512',
-    team: 'ECT'
+    team: 'ECT',
+    onlineStatus: fetchOnlineStatus('UCL31R6KU')
   },
   {
     name: 'Tomas',
     timezone: 'Europe/Dublin',
     gender: 'male',
     avatarUrl: 'https://ca.slack-edge.com/T0P6BBP1N-U6278RRE3-8bace14f04b9-512',
-    team: 'ECT'
+    team: 'ECT',
+    onlineStatus: fetchOnlineStatus('U6278RRE3')
   },
   {
     name: 'Ursula',
     timezone: 'Europe/Tallinn',
     gender: 'female',
     avatarUrl: 'https://ca.slack-edge.com/T0P6BBP1N-UCXR81C49-4a5b9245e263-512',
-    team: 'ECT'
+    team: 'ECT',
+    onlineStatus: fetchOnlineStatus('UCXR81C49')
   },
   {
     name: 'Dan M',
     timezone: 'Europe/Kiev',
     gender: 'male',
     avatarUrl: 'https://ca.slack-edge.com/T0P6BBP1N-U011DRA8KGW-g70d54f080ff-512',
-    team: 'ECT'
+    team: 'ECT',
+    onlineStatus: fetchOnlineStatus('U011DRA8KGW')
   },
   {
     name: 'Lynsey',
     timezone: 'Europe/London',
     gender: 'female',
     avatarUrl: 'https://ca.slack-edge.com/T0P6BBP1N-UB1U1EGB0-93a5bdc616ab-512',
-    team: 'ECT'
+    team: 'ECT',
+    onlineStatus: fetchOnlineStatus('UB1U1EGB0')
   },
   {
     name: 'Iva',
     timezone: 'Europe/London',
     gender: 'female',
     avatarUrl: 'https://ca.slack-edge.com/T0P6BBP1N-ULNRA693L-6209b1706303-512',
-    team: 'ECT'
+    team: 'ECT',
+    onlineStatus: fetchOnlineStatus('ULNRA693L')
   },
   {
     name: 'Brett',
     timezone: 'Europe/London',
     gender: 'male',
     avatarUrl: 'https://ca.slack-edge.com/T0P6BBP1N-UAXH5FK7V-7f7a3aa35535-512',
-    team: 'NCT'
+    team: 'NCT',
+    onlineStatus: fetchOnlineStatus('UAXH5FK7V')
   },
   {
     name: 'Carolina',
     timezone: 'Europe/London',
     gender: 'female',
     avatarUrl: 'https://ca.slack-edge.com/T0P6BBP1N-UDE7Z0ME2-ae2029c08327-512',
-    team: 'NCT'
+    team: 'NCT',
+    onlineStatus: fetchOnlineStatus('UDE7Z0ME2')
   },
   {
     name: 'Despi',
     timezone: 'Europe/London',
     gender: 'female',
     avatarUrl: 'https://ca.slack-edge.com/T0P6BBP1N-USCG9TATY-g265149b88f2-512',
-    team: 'NCT'
+    team: 'NCT',
+    onlineStatus: fetchOnlineStatus('USCG9TATY')
   },
   {
     name: 'Dan F',
     timezone: 'Asia/Jerusalem',
     gender: 'male',
     avatarUrl: 'https://ca.slack-edge.com/T0P6BBP1N-UL5P8KPJA-08be4e5e1b3b-512',
-    team: 'NCT'
+    team: 'NCT',
+    onlineStatus: fetchOnlineStatus('UL5P8KPJA')
   },
   {
     name: 'Bernadette',
     timezone: 'Europe/London',
     gender: 'female',
     avatarUrl: 'https://ca.slack-edge.com/T0P6BBP1N-UCZAK8EBW-1faaaf3d65cf-512',
-    team: 'NCT'
+    team: 'NCT',
+    onlineStatus: fetchOnlineStatus('UCZAK8EBW')
   },
   {
     name: 'Hannah',
     timezone: 'Europe/London',
     gender: 'female',
     avatarUrl: 'https://ca.slack-edge.com/T0P6BBP1N-U74D7GZ7E-8a5abb485474-512',
-    team: 'NCT'
+    team: 'NCT',
+    onlineStatus: fetchOnlineStatus('U74D7GZ7E')
   },
   {
     name: 'Adrian',
     timezone: 'Europe/London',
     gender: 'male',
     avatarUrl: 'https://ca.slack-edge.com/T0P6BBP1N-US9S54K4L-g3c65da64eb4-512',
-    team: 'Platform'
+    team: 'Platform',
+    onlineStatus: fetchOnlineStatus('US9S54K4L')
   },
   {
     name: 'James E',
     timezone: 'Europe/London',
     gender: 'male',
     avatarUrl: 'https://ca.slack-edge.com/T0P6BBP1N-U01441V313L-g4ffa7040829-512',
-    team: 'Platform'
+    team: 'Platform',
+    onlineStatus: fetchOnlineStatus('U01441V313L')
   },
   {
     name: 'Niall',
     timezone: 'Europe/London',
     gender: 'male',
     avatarUrl: 'https://ca.slack-edge.com/T0P6BBP1N-U5UFFTF52-f5fa75b2a988-512',
-    team: 'All'
+    team: 'All',
+    onlineStatus: fetchOnlineStatus('U5UFFTF52')
   },
   {
     name: 'Alex',
     timezone: 'Europe/London',
     gender: 'male',
     avatarUrl: 'https://ca.slack-edge.com/T0P6BBP1N-U92882KNH-d833d845d1cc-512',
-    team: 'All'
+    team: 'All',
+    onlineStatus: fetchOnlineStatus('U92882KNH')
   }
 ]
 


### PR DESCRIPTION
Now we are able to get a team members Slack presence through the Netlify
function in a previous commit. We are able to use this on the front-end to
accurately reflect a users true online status.